### PR TITLE
Se habilita SSL en el transcendence

### DIFF
--- a/back/core/core/asgi.py
+++ b/back/core/core/asgi.py
@@ -10,20 +10,20 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
-from .JWTAuthMiddlewareStack import JWTAuthMiddlewareStack
-from game.routing import websocket_game
-from chat.routing import websocket_chat
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
-
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
 
+django_asgi_app = get_asgi_application()
+from .JWTAuthMiddlewareStack import JWTAuthMiddlewareStack
+from game.routing import websocket_game
+from chat.routing import websocket_chat
 all_websocket_routes = websocket_game + websocket_chat
 
 application = ProtocolTypeRouter(
     {
-        "http": get_asgi_application(),
+        "http": django_asgi_app,
         "websocket": JWTAuthMiddlewareStack(
             URLRouter(
                 all_websocket_routes

--- a/back/core/core/asgi.py
+++ b/back/core/core/asgi.py
@@ -8,13 +8,13 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 """
 
 import os
-
+from django import setup
 from django.core.asgi import get_asgi_application
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
-
+setup()
 django_asgi_app = get_asgi_application()
 from .JWTAuthMiddlewareStack import JWTAuthMiddlewareStack
 from game.routing import websocket_game

--- a/back/core/core/settings.py
+++ b/back/core/core/settings.py
@@ -32,6 +32,7 @@ DEBUG = True
 #ALLOWED_HOSTS = ['*']
 # Production all containers that should be able to call django endpoints
 ALLOWED_HOSTS = ['localhost','django','prometheus', 'nginx', 'db']
+# TODO review if all these hosts are necesary to be allowed
 
 
 # Application definition

--- a/back/core/core/settings.py
+++ b/back/core/core/settings.py
@@ -29,9 +29,9 @@ SECRET_KEY = 'django-insecure-qfcaph4ab)-2t0nvaj_4tzndz!4@s1ej^^vb3b1gu@&j)r2c)a
 DEBUG = True
 
 # Development
-ALLOWED_HOSTS = ['*']
+#ALLOWED_HOSTS = ['*']
 # Production all containers that should be able to call django endpoints
-#ALLOWED_HOSTS = ['prometheus', 'nginx', 'db']
+ALLOWED_HOSTS = ['localhost','django','prometheus', 'nginx', 'db']
 
 
 # Application definition
@@ -204,12 +204,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # CORS configuration
 CORS_ALLOWED_ORIGINS = [
 #    "http://localhost:80",
-    "http://nginx:80",
+    "https://nginx:443",
 ]
 
 CORS_ORIGIN_WHITELIST = [
 #    "http://localhost:80",
-    "http://nginx:80",
+    "https://nginx:443",
 ]
 
 LOGGING = {

--- a/back/core/pong_auth/views.py
+++ b/back/core/pong_auth/views.py
@@ -80,7 +80,7 @@ class User42Callback(generics.GenericAPIView):
             'client_id': client_id,
             'client_secret': client_secret,
             'code': code,
-            'redirect_uri': "http://localhost:80",
+            'redirect_uri': "https://localhost:443",
             'state': state
         }
         # Make request to get 42 credentials for more information

--- a/back/core/pong_auth/views.py
+++ b/back/core/pong_auth/views.py
@@ -80,7 +80,7 @@ class User42Callback(generics.GenericAPIView):
             'client_id': client_id,
             'client_secret': client_secret,
             'code': code,
-            'redirect_uri': "https://localhost:443",
+            'redirect_uri': "https://localhost:443", ## If we set a domain, we need to change this variable
             'state': state
         }
         # Make request to get 42 credentials for more information

--- a/back/core/script.sh
+++ b/back/core/script.sh
@@ -12,4 +12,4 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/ngi
 #Use wsgi when going to production
 #python3 manage.py runserver 0.0.0.0:8000
 export DJANGO_SETTINGS_MODULE=core.settings
-daphne -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application
+daphne -v 3 -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application

--- a/back/core/script.sh
+++ b/back/core/script.sh
@@ -10,6 +10,6 @@ python manage.py check
 
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=ES/L=Madrid/CN=localhost"
 #Use wsgi when going to production
-#python3 manage.py runserver 0.0.0.0:8000
 export DJANGO_SETTINGS_MODULE=core.settings
-daphne -v 3 -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application
+# pass flag -v 3 to daphne for verbose option
+daphne -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application

--- a/back/core/script.sh
+++ b/back/core/script.sh
@@ -4,8 +4,12 @@ python3 manage.py makemigrations --no-input
 
 python3 manage.py migrate --no-input --run-syncdb
 
+python manage.py check
 #We are not going to use static since nginx will handle the frontend
 #python3 manage.py collectstatic --no-input
 
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=ES/L=Madrid/CN=localhost"
 #Use wsgi when going to production
-python3 manage.py runserver 0.0.0.0:8000
+#python3 manage.py runserver 0.0.0.0:8000
+export DJANGO_SETTINGS_MODULE=core.settings
+daphne -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application

--- a/back/core/script.sh
+++ b/back/core/script.sh
@@ -4,12 +4,12 @@ python3 manage.py makemigrations --no-input
 
 python3 manage.py migrate --no-input --run-syncdb
 
-python manage.py check
 #We are not going to use static since nginx will handle the frontend
 #python3 manage.py collectstatic --no-input
 
+# TODO if we pay for domain, maybe we need to change this
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=ES/L=Madrid/CN=localhost"
 #Use wsgi when going to production
-export DJANGO_SETTINGS_MODULE=core.settings
+#export DJANGO_SETTINGS_MODULE=core.settings
 # pass flag -v 3 to daphne for verbose option
 daphne -e ssl:8000:privateKey=/etc/ssl/private/nginx-selfsigned.key:certKey=/etc/ssl/certs/nginx-selfsigned.crt core.asgi:application

--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
     build: ./front/
     container_name: nginx
     ports:
-      - 80:80
+      - 443:443
     volumes:
       - profile_pictures:/media
     depends_on:
@@ -95,7 +95,7 @@ services:
     expose:
       - 9113
     command:
-      - --nginx.scrape-uri=http://nginx:80/nginx_status
+      - --nginx.scrape-uri=https://nginx:443/nginx_status
     depends_on:
       - prometheus
       - nginx
@@ -105,3 +105,5 @@ volumes:
   profile_pictures:
   prom_data:
   graf_data:
+#TODO meter daphne para los wss https://forum.djangoproject.com/t/secure-websocket-with-https/16801
+# https://github.com/django/daphne

--- a/compose.yml
+++ b/compose.yml
@@ -8,16 +8,18 @@ services:
       - 443:443
     volumes:
       - profile_pictures:/media
+    networks:
+      - transcendence
     depends_on:
       - django
 
   django:
     build: ./back/
     container_name: django
-    ports:
-      - 8000:8000
     volumes:
       - profile_pictures:/core/media
+    networks:
+      - transcendence
     env_file:
       - .env
     depends_on:
@@ -26,10 +28,10 @@ services:
   db:
     build: ./db/
     container_name: db
-    expose:
-      - 5432
     volumes:
       - ddbb:/var/lib/postgresql/data
+    networks:
+      - transcendence
     env_file:
       - .env
 
@@ -37,25 +39,35 @@ services:
     image: "redis:7.2.3-alpine"
     container_name: "redis"
     command: ["redis-server", "--bind", "redis", "--port", "6379"]
+    networks:
+      - transcendence
       
 # Monitoring
   prometheus:
     image: prom/prometheus:v2.49.1
     container_name: prometheus
-    ports:
-      - "9090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml
       - prom_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.route-prefix=/'
+      - '--web.external-url=https://localhost/monitoring/prometheus'
+    networks:
+      - transcendence
   
   alertmanager:
     image: prom/alertmanager:v0.21.0
     container_name: alertmanager
-    ports:
-      - "9093:9093"
     volumes:
       - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--web.route-prefix=/'
+      - '--web.external-url=https://localhost/monitoring/alertmanager'
+    networks:
+      - transcendence
 
 
 # Django dashboard 17658
@@ -64,16 +76,17 @@ services:
   grafana:
     image: grafana/grafana:10.3.1
     container_name: grafana
-    ports:
-      - 3000:3000
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - graf_data:/var/lib/grafana
+    networks:
+      - transcendence
     environment:
     #TODO Secure this credentials, for now development doesnt matter
       - GF_SECURITY_ADMIN_USER=test-user
       - GF_SECURITY_ADMIN_PASSWORD=test
+      - GF_SERVER_ROOT_URL=https://localhost/monitoring/grafana/
     depends_on:
       - prometheus
 
@@ -81,8 +94,8 @@ services:
   postgres_exporter:
     image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
     container_name: postgres_exporter
-    expose:
-      - 9187
+    networks:
+      - transcendence
     environment:
       - DATA_SOURCE_NAME=postgresql://postgres:postgres@db:5432/postgres?sslmode=disable
     depends_on:
@@ -92,18 +105,20 @@ services:
   nginx_exporter:
     image: nginx/nginx-prometheus-exporter:1.1.0
     container_name: nginx_exporter
-    expose:
-      - 9113
+    networks:
+      - transcendence
     command:
       - --nginx.scrape-uri=https://nginx:443/nginx_status
     depends_on:
       - prometheus
       - nginx
 
+networks:
+  transcendence:
+    name: transcendence
+
 volumes:
   ddbb:
   profile_pictures:
   prom_data:
   graf_data:
-#TODO meter daphne para los wss https://forum.djangoproject.com/t/secure-websocket-with-https/16801
-# https://github.com/django/daphne

--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,9 @@ services:
     container_name: django
     volumes:
       - profile_pictures:/core/media
+    # Please only access directly to django if you want to go admin or swagger dashboard 
+    ports:
+      - 8000:8000
     networks:
       - transcendence
     env_file:

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -4,6 +4,7 @@ COPY ./default.conf /etc/nginx/conf.d/default.conf
 
 COPY ./html/ /usr/share/nginx/html/
 
+# TODO Review this cert creation in case we set a domain
 RUN openssl req -x509 -nodes -days 365 -newkey \
     rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key \
     -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=ES/L=Madrid/CN=localhost"

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -3,3 +3,7 @@ FROM nginx:stable-bullseye-perl
 COPY ./default.conf /etc/nginx/conf.d/default.conf
 
 COPY ./html/ /usr/share/nginx/html/
+
+RUN openssl req -x509 -nodes -days 365 -newkey \
+    rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key \
+    -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/C=ES/L=Madrid/CN=localhost"

--- a/front/default.conf
+++ b/front/default.conf
@@ -29,6 +29,7 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
+
     # Monitoring
     location /monitoring/grafana/ {
         proxy_pass http://grafana:3000/;
@@ -37,11 +38,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
-
         proxy_redirect off;
     }
 
@@ -52,11 +50,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
-
         proxy_redirect off;
     }
     
@@ -67,11 +62,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
-
         proxy_redirect off;
     }
     

--- a/front/default.conf
+++ b/front/default.conf
@@ -1,14 +1,19 @@
 server {
-    listen 80;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name localhost;
     root /usr/share/nginx/html;
 
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+	ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+    ssl_protocols TLSv1.3;
+    
     location / {
         try_files $uri $uri/ index.html;
     }
 
      location /api {
-        proxy_pass http://django:8000;
+        proxy_pass https://django:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/front/default.conf
+++ b/front/default.conf
@@ -29,7 +29,52 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
+    # Monitoring
+    location /monitoring/grafana/ {
+        proxy_pass http://grafana:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
+    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
+
+        proxy_redirect off;
+    }
+
+    location /monitoring/prometheus/ {
+        proxy_pass http://prometheus:9090/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
+
+        proxy_redirect off;
+    }
+    
+    location /monitoring/alertmanager/ {
+        proxy_pass http://alertmanager:9093/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Es importante para que Grafana sepa cómo reescribir sus URLs internas correctamente.
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Prefix /monitoring/grafana;
+
+        proxy_redirect off;
+    }
+    
     location /nginx_status {
         stub_status on;
     }

--- a/front/default.conf
+++ b/front/default.conf
@@ -12,7 +12,16 @@ server {
         try_files $uri $uri/ index.html;
     }
 
-     location /api {
+    location /ws {
+        proxy_pass https://django:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api {
         proxy_pass https://django:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/front/html/callback/callback.js
+++ b/front/html/callback/callback.js
@@ -11,6 +11,7 @@ async function handleSubmitUpdatedData(e) {
         username: username,
       };
       try {
+            // TODO probably we need to change localhost to domain
             const response = await fetch('https://localhost:443/api/user_management/user_update/', {
             method: 'PATCH',
             headers: {

--- a/front/html/callback/callback.js
+++ b/front/html/callback/callback.js
@@ -11,7 +11,7 @@ async function handleSubmitUpdatedData(e) {
         username: username,
       };
       try {
-            const response = await fetch('http://localhost:80/api/user_management/user_update/', {
+            const response = await fetch('https://localhost:443/api/user_management/user_update/', {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -53,7 +53,7 @@ export async function callback42(e) {
 
     // Make a POST request to your backend with the authorization code
     if (authorizationCode) {
-        const response = await fetch('http://localhost:80/api/pong_auth/42/callback/', {
+        const response = await fetch('https://localhost:443/api/pong_auth/42/callback/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/front/html/index/menu.js
+++ b/front/html/index/menu.js
@@ -3,7 +3,7 @@ import { renewJWT } from "../components/updatejwt.js"
 export async function loadUserInfo() {
     const token = sessionStorage.getItem('token')
     try {
-        const response = await fetch('http://localhost:80/api/user_management/user_list/', {
+        const response = await fetch('https://localhost:443/api/user_management/user_list/', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',

--- a/front/html/login/login.html
+++ b/front/html/login/login.html
@@ -15,7 +15,7 @@
             <div class="login-buttons">
                 <button type="submit" class="btn btn-primary">Login</button>
                 <button type="button" class="btn btn-info login-42"
-                    onclick="location.href='https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fabc70636434a6e13642cb70d96dd9b25d6d0d1416e676828df55c45808e06bc&redirect_uri=http%3A%2F%2Flocalhost%3A80&response_type=code'">Login with 42</button>
+                    onclick="location.href='https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fabc70636434a6e13642cb70d96dd9b25d6d0d1416e676828df55c45808e06bc&redirect_uri=https%3A%2F%2Flocalhost%3A443&response_type=code'">Login with 42</button>
             </div>
         </form>
     </div>

--- a/front/html/login/login.js
+++ b/front/html/login/login.js
@@ -15,7 +15,7 @@ async function handleSubmitLogin (e) {
     };
     try {
         // Make a POST request to the specified endpoint
-        const response = await fetch('http://localhost:80/api/pong_auth/login/', {
+        const response = await fetch('https://localhost:443/api/pong_auth/login/', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/front/html/sing-up/signup.js
+++ b/front/html/sing-up/signup.js
@@ -14,7 +14,7 @@ async function handleSubmitRegister(e) {
         password: password,
     };
     try {
-        const response = await fetch('http://localhost:80/api/pong_auth/register/', {
+        const response = await fetch('https://localhost:443/api/pong_auth/register/', {
             method: 'POST',
             headers: {
             'Content-Type': 'application/json',

--- a/front/html/socket/ChatSocketManager.js
+++ b/front/html/socket/ChatSocketManager.js
@@ -25,7 +25,6 @@ export class ChatSocketManager extends SocketManager {
     
     onError(event)
     {
-        console.error("estoy on error =(")
         if (this.callbacks[SOCKET.ERROR]) {
             this.callbacks[SOCKET.ERROR].forEach(callback => callback(event));
         }

--- a/front/html/socket/ChatSocketManager.js
+++ b/front/html/socket/ChatSocketManager.js
@@ -25,6 +25,7 @@ export class ChatSocketManager extends SocketManager {
     
     onError(event)
     {
+        console.error("estoy on error =(")
         if (this.callbacks[SOCKET.ERROR]) {
             this.callbacks[SOCKET.ERROR].forEach(callback => callback(event));
         }

--- a/front/html/socket/SocketManager.js
+++ b/front/html/socket/SocketManager.js
@@ -8,7 +8,8 @@ export class SocketManager {
         if(this.socket === undefined)
         {
             let token = sessionStorage.getItem('token');
-            this.socket = new WebSocket(`ws://localhost:8000/${this.path}/?token=${token}`);
+            console.error(this.path);
+            this.socket = new WebSocket(`wss://localhost:8000/${this.path}/?token=${token}`);
             this.setupSocketEvents();
         }
     }
@@ -16,7 +17,7 @@ export class SocketManager {
     disconnect()
     {
         const code = 3008;
-        const reasson = 'Unespected';
+        const reasson = 'Unexpected';
         if(this.socket.readyState === WebSocket.OPEN) {
             this.socket.close(code, reasson);
             this.socket = undefined;
@@ -49,6 +50,7 @@ export class SocketManager {
             }));
         } else {
             console.error('WebSocket connection not open. Unable to send message:', sendMessage);
+            console.error("No se si pasa popr aquí:", this.path);
         }
     }
 

--- a/front/html/socket/SocketManager.js
+++ b/front/html/socket/SocketManager.js
@@ -5,11 +5,15 @@ export class SocketManager {
 
     connect() {
         // Prevent reconnection on navigation
+        console.error("Se conecta el cokset 1");
         if(this.socket === undefined)
         {
             let token = sessionStorage.getItem('token');
-            console.error(this.path);
-            this.socket = new WebSocket(`wss://localhost:8000/${this.path}/?token=${token}`);
+            //console.error(this.path);
+            this.socket = new WebSocket(`wss://localhost:443/${this.path}/?token=${token}`);
+            //console.log('WebSocket object created:', this.socket);
+            //console.log('WebSocket readyState:', this.socket.readyState);
+            //console.error("Se conecta el socket");
             this.setupSocketEvents();
         }
     }

--- a/front/html/socket/SocketManager.js
+++ b/front/html/socket/SocketManager.js
@@ -9,11 +9,7 @@ export class SocketManager {
         if(this.socket === undefined)
         {
             let token = sessionStorage.getItem('token');
-            //console.error(this.path);
             this.socket = new WebSocket(`wss://localhost:443/${this.path}/?token=${token}`);
-            //console.log('WebSocket object created:', this.socket);
-            //console.log('WebSocket readyState:', this.socket.readyState);
-            //console.error("Se conecta el socket");
             this.setupSocketEvents();
         }
     }
@@ -54,7 +50,6 @@ export class SocketManager {
             }));
         } else {
             console.error('WebSocket connection not open. Unable to send message:', sendMessage);
-            console.error("No se si pasa popr aquí:", this.path);
         }
     }
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -7,18 +7,10 @@ alerting:
     - scheme: http
       static_configs:
         - targets:
-            - "alertmanagers::9093"
+            - "alertmanager:9093"
 rule_files:
   - "./alert_rules.yml"
 scrape_configs:
-  #- job_name: prometheus
-  #  scrape_interval: 15s
-  #  scrape_timeout: 10s
-  #  scheme: http
-  #  static_configs:
-  #  - targets:
-  #    - localhost:9090
-
   - job_name: 'postgres'
     static_configs:
       - targets:
@@ -28,6 +20,9 @@ scrape_configs:
       - targets:
         - nginx_exporter:9113
   - job_name: 'django'
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
     static_configs:
       - targets:
         - django:8000


### PR DESCRIPTION
Se crean por ahora los certificados SSL para utilizarlos en django y en nginx.
Se modifica la configuración de red para que los servicios únicamente sean accesibles por https en el puerto 443 de nginx, asegurando un único método de entrada a cualquier parte de nuestro proyecto desde la red externa.