### PR TITLE
2FA confirmation

### DIFF
--- a/back/core/user_management/serializers.py
+++ b/back/core/user_management/serializers.py
@@ -11,7 +11,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CustomUser
-        fields = ('username', 'status', 'profile_picture', 'TwoFactorAuth')
+        fields = ('username', 'profile_picture',)
 
     def update(self, instance, validated_data):
         previous_profile_picture = instance.profile_picture
@@ -19,15 +19,25 @@ class UserUpdateSerializer(serializers.ModelSerializer):
             previous_profile_picture.delete()
         instance.profile_picture = validated_data.get('profile_picture', instance.profile_picture)
         instance.username        = validated_data.get('username', instance.username)
-        instance.status          = validated_data.get('status', instance.status)
-        if (validated_data.get('TwoFactorAuth', instance.TwoFactorAuth) == True):
-            instance.OTP_SECRET_KEY = pyotp.random_base32()
-        else:
-            instance.OTP_SECRET_KEY = 0            
-        instance.TwoFactorAuth   = validated_data.get('TwoFactorAuth', instance.TwoFactorAuth)
         instance.save()
         return instance
+
+class UserUpdateTwoFactorAuthSerializer(serializers.ModelSerializer):
+    TwoFactorAuth = serializers.BooleanField(required=True)
     
+    class Meta:
+        model = CustomUser
+        fields = ('TwoFactorAuth',)
+
+    def update(self, instance, validated_data):
+        if validated_data.get('TwoFactorAuth') == True:
+            instance.OTP_SECRET_KEY = pyotp.random_base32()
+        else:
+            instance.OTP_SECRET_KEY = None
+            instance.TwoFactorAuth   = validated_data.get('TwoFactorAuth', instance.TwoFactorAuth)
+        instance.save()
+        return instance
+
 class UserUpdatePasswordSerializer(serializers.Serializer):
 
     old_password  = serializers.CharField(required=True)

--- a/back/core/user_management/serializers.py
+++ b/back/core/user_management/serializers.py
@@ -30,7 +30,8 @@ class UserUpdateTwoFactorAuthSerializer(serializers.ModelSerializer):
         fields = ('TwoFactorAuth',)
 
     def update(self, instance, validated_data):
-        if validated_data.get('TwoFactorAuth') == True:
+        user = self.context.get('user')
+        if validated_data.get('TwoFactorAuth') == True and user.TwoFactorAuth == False:
             instance.OTP_SECRET_KEY = pyotp.random_base32()
         else:
             instance.OTP_SECRET_KEY = None

--- a/back/core/user_management/urls.py
+++ b/back/core/user_management/urls.py
@@ -4,6 +4,8 @@ from . import views
 urlpatterns = [
     path('user_update/', views.UserUpdateView.as_view(), name='user-update'),
     path('user_update_password/', views.UserUpdatePasswordView.as_view(), name='user-update-password'),
+	path('user_update_2FA/', views.UserUpdateActivate2FA.as_view(), name='user-update-2FA'),
+    path('user_update_validate_2FA/', views.UserUpdateValidateOTPView.as_view(), name='user-validate-otp'),
     path('user_delete/', views.UserDeleteView.as_view(), name='user-delete'),
     path('user_list/', views.UserListView.as_view(), name='user-list'),
     path('user_list_all/', views.UserListAllView.as_view(), name='user-list-all'),

--- a/back/core/user_management/views.py
+++ b/back/core/user_management/views.py
@@ -46,10 +46,12 @@ class UserUpdateActivate2FA(generics.GenericAPIView):
 
 	def patch(self, request):
 		user = request.user
-		user_serializer = self.serializer_class(user, data=request.data)
+		user_serializer = self.serializer_class(user, data=request.data, context={'user': user})
 		if user_serializer.is_valid():
 			user_serializer.save()
 			if user_serializer.validated_data.get('TwoFactorAuth') == True:
+				if user.TwoFactorAuth == True:
+					return Response({'message':'Already activated'}, status=status.HTTP_400_BAD_REQUEST)
 				encoded_qr = GenerateQR(user)
 				return Response({'message': 'Please confirm the following code',
 					'qr' : encoded_qr,

--- a/back/core/user_management/views.py
+++ b/back/core/user_management/views.py
@@ -49,7 +49,7 @@ class UserUpdateActivate2FA(generics.GenericAPIView):
 		user_serializer = self.serializer_class(user, data=request.data)
 		if user_serializer.is_valid():
 			user_serializer.save()
-			if user_serializer.data['TwoFactorAuth'] is not None:
+			if user_serializer.validated_data.get('TwoFactorAuth') == True:
 				encoded_qr = GenerateQR(user)
 				return Response({'message': 'Please confirm the following code',
 					'qr' : encoded_qr,

--- a/front/html/profile/editProfile.html
+++ b/front/html/profile/editProfile.html
@@ -1,4 +1,4 @@
-<div class="container mt-5">
+<div class="container mt-5" id="update_forms">
     <h1>Edit Profile</h1>
     <form id="editProfileForm">
         <div class="mb-3">

--- a/front/html/profile/editProfile.html
+++ b/front/html/profile/editProfile.html
@@ -11,6 +11,33 @@
         </div>
         <button type="submit" class="btn btn-primary">Save Changes</button>
     </form>
+    <!-- Modal -->
+    <div class="modal fade" id="twoFactorAuthModal" tabindex="-1" role="dialog" aria-labelledby="twoFactorAuthModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="twoFactorAuthModalLabel">Enter OTP</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form id="confirmOTP">
+                        <div class="form-group">
+                            <input type="text" id="OTP" autocomplete="off" class="form-control" required="required" placeholder="OTP">
+                        </div>
+                        <div class="text-center">
+                            <img class="qrcode" id="qrCodeImg" src="" alt="QR code">
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                            <button type="submit" class="btn btn-primary">Confirm OTP</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
     <form id="activateTwoFactorAuthForm">
         <div class="form-check mb-3">
             <label class="form-check-label" for="twoFactorAuth">Activate Two-Factor Authentication</label>

--- a/front/html/profile/editProfile.html
+++ b/front/html/profile/editProfile.html
@@ -9,18 +9,21 @@
             <label for="new_profilePicture" class="form-label">Profile Picture</label>
             <input type="file" class="form-control" id="new_profilePicture">
         </div>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+    </form>
+    <form id="activateTwoFactorAuthForm">
         <div class="form-check mb-3">
             <label class="form-check-label" for="twoFactorAuth">Activate Two-Factor Authentication</label>
             <div class="form-check">
-                <input class="form-check-input" type="radio" name="twoFactorAuth" id="twoFactorAuthTrue" value="true">
+                <input class="form-check-input" type="radio" name="twoFactorAuth" id="twoFactorAuthTrue" value="true" required="required">
                 <label class="form-check-label" for="twoFactorAuthTrue">Yes</label>
             </div>
             <div class="form-check">
-                <input class="form-check-input" type="radio" name="twoFactorAuth" id="twoFactorAuthFalse" value="false">
+                <input class="form-check-input" type="radio" name="twoFactorAuth" id="twoFactorAuthFalse" value="false" required="required">
                 <label class="form-check-label" for="twoFactorAuthFalse">No</label>
             </div>
+            <button type="submit" class="btn btn-primary">Save Changes</button>
         </div>
-        <button type="submit" class="btn btn-primary">Save Changes</button>
     </form>
     <form id="changePasswordForm">
         <div class="mb-3">

--- a/front/html/profile/profileScript.js
+++ b/front/html/profile/profileScript.js
@@ -103,7 +103,7 @@ async function update2FA()
     const data = await response.json();
     if (response.status === 307)
     {
-        let qr_code = document.getElementById('activateTwoFactorAuthForm');
+        let qr_code = document.getElementById('update_forms');
         // Use template literals and remove the '+ ' before data.qr
         console.log(qr_code)
         let qr = 'data:image/png;base64,' + data.qr;

--- a/front/html/profile/profileScript.js
+++ b/front/html/profile/profileScript.js
@@ -1,6 +1,5 @@
 import { renewJWT } from "../components/updatejwt.js"
 import { displayErrorList, displayError } from "../components/loader.js"
-import { load2FApage } from "../2FA/twoFactorAuthScript.js"
 
 export async function loadUserInfo() {
     const token = sessionStorage.getItem('token')
@@ -77,7 +76,7 @@ function updateUser(e)
         updatePassword();
     else if (e.target.matches('#activateTwoFactorAuthForm') == true)
         update2FA();
-    else if (e.target.matches('#confirmSendOTPForm') == true)
+    else if (e.target.matches('#confirmOTP') == true)
         TwoFactorAuthConfirmOTPUpdate();
 }
 
@@ -103,27 +102,9 @@ async function update2FA()
     const data = await response.json();
     if (response.status === 307)
     {
-        let qr_code = document.getElementById('update_forms');
-        // Use template literals and remove the '+ ' before data.qr
-        console.log(qr_code)
-        let qr = 'data:image/png;base64,' + data.qr;
-        var htmlDinamico = `
-        <div class="form">
-            <h2><b>Enter QR code</b></h2>
-            <form id="confirmSendOTPForm">
-                <div class="form-group">
-                    <input type="text" id="OTP" autocomplete="off" class="form-control OTPInput" required="required" placeholder="OTP">
-                </div>
-                <div class="submit-buttons">
-                    <button type="submit" class="btn btn-primary">Confirm OTP</button>
-                </div>
-            </form>
-        </div>
-        <div class="vertical-center">
-            <img class="qrcode" src='${qr}' alt="QR code">
-        </div>
-        `;
-        qr_code.innerHTML += htmlDinamico;
+        document.getElementById('qrCodeImg').src = 'data:image/png;base64,' + data.qr;
+        // Show modal
+        $('#twoFactorAuthModal').modal('show');
     }
     } catch (error) {
         displayError(error.message, 'small', 'activateTwoFactorAuthForm');
@@ -221,7 +202,7 @@ async function TwoFactorAuthConfirmOTPUpdate() {
         console.log(response)
         } catch (error) {
             console.error('Error:', error.message);
-            displayError(error.message, 'small', 'confirmSendOTPForm');
+            displayError(error.message, 'small', 'confirmOTP');
         }
 }
 


### PR DESCRIPTION
Actualmente si activas 2FA y no escaneas el QR, pierdes la cuenta.
La solución de esta PR implica mostrar el QR antes de activar la doble verificación y verificar el código una primera vez.
Además cubre casos como usuarios que ya tienen activado el 2FA queriendo activarlo de nuevo (los rechaza)